### PR TITLE
Fixed PropTypes warning on RN 0.55

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export default class CleanWebView extends Component {
   }
 }
 
-CleanWebView.PropTypes = {
+CleanWebView.propTypes = {
   url: PropTypes.string.isRequired,
   htmlCss: PropTypes.string,
   onCleaned: PropTypes.func,


### PR DESCRIPTION
Fixed "Component CleanWebView declared PropTypes instead of propType" warning on React Native 0.55 (see screenshot below):

![simulator screen shot - iphone x - 2018-05-05 at 16 27 22](https://user-images.githubusercontent.com/19588613/39664287-4693f754-5081-11e8-85ce-e6ab18f054d5.png)
